### PR TITLE
Add Arlington Ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Reach out to the speakers whose talks interest you!
 ### Participating Meetups
 
 - [ACM Washington DC](https://www.meetup.com/ACM-DC/)
+- [Arlington Ruby](https://www.meetup.com/Arlington-Ruby/)
 - [Art + Code Collective](https://www.meetup.com/Art-Code-Collective/members/?sort=join_date&desc=true)
 - [DC VueVixens](https://www.meetup.com/VueVixens-DC/)
 - [VueDC](https://www.meetup.com/vue-dc/)


### PR DESCRIPTION
Added [Arlington Ruby](https://www.meetup.com/Arlington-Ruby/). I inserted into the list with alphabetical tendencies (since it made sense in my head) but also noticed that may not be the current convention 🤔