### PR TITLE
feature: Add template for requesting talks by topic

### DIFF
--- a/.github/ISSUE_TEMPLATE/request.md
+++ b/.github/ISSUE_TEMPLATE/request.md
@@ -1,0 +1,24 @@
+---
+name: Request
+labels: request
+about: Submit a request for talks on a given topic
+---
+
+## Talk Request
+
+**Topic(s):**
+
+**Additional Notes:**
+
+**What would the ideal length be?**
+- [ ] 5-15 minutes (lightning talk)
+- [ ] 20-30 minutes
+- [ ] 30-45 minutes
+- [ ] 60 minutes or more
+
+## On Behalf Of
+
+**Requesting people or Meetups:**
+
+**The best way to reach out to them:**
+

--- a/.github/ISSUE_TEMPLATE/talk.md
+++ b/.github/ISSUE_TEMPLATE/talk.md
@@ -1,5 +1,6 @@
 ---
 name: Talk
+labels: talk
 about: Submit a talk idea to participating meetups.
 ---
 


### PR DESCRIPTION
Auto-apply 'request' & 'talk' labels at time of issue creation, to potentially allow different auto-responses in the future