### PR TITLE
Update auto-reply, stale bots.

### DIFF
--- a/.github/auto-comment.yml
+++ b/.github/auto-comment.yml
@@ -1,5 +1,5 @@
 # Comment to a new issue.
-issueOpened: >
+issuesOpened: >
   Hi there! Thank you for taking the time to submit a talk! Speakers like you make the DC tech community awesome — and we’re glad you’re here.
 
   Rest assured that organizers of quite a few meetups have just been notified of your proposal.

--- a/.github/auto-comment.yml
+++ b/.github/auto-comment.yml
@@ -1,9 +1,6 @@
 # Comment to a new issue.
 issuesOpened: >
-  Hi there! Thank you for taking the time to submit a talk! Speakers like you make the DC tech community awesome — and we’re glad you’re here.
-
-  Rest assured that organizers of quite a few meetups have just been notified of your proposal.
-
-  **Want to target one or two groups specifically?** Mention the group by tagging <code>@dctech/[group]</code> — but please avoid tagging groups at random or tagging more than one or two. Thanks for keeping this group productive and spam-free!
-
-  **Not interested in giving this talk anymore?** Not a problem at all! Thanks for considering it in the first place! Go ahead and close this issue, so we know not to bother you about it.
+  <p>Hi there! Thank you for taking the time to submit a talk! Speakers like you make the DC tech community awesome — and we’re glad you’re here.</p>
+  <p>Rest assured that organizers of quite a few meetups have just been notified of your proposal.</p>
+  <p><strong>Want to target one or two groups specifically?</strong> Mention the group by tagging <code>@dctech/[group]</code> — but please avoid tagging groups at random or tagging more than one or two. Thanks for keeping this group productive and spam-free!</p>
+  <p><strong>Not interested in giving this talk anymore?</strong> Not a problem at all! Thanks for considering it in the first place! Go ahead and close this issue, so we know not to bother you about it.</p>

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,22 +7,19 @@ daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
   - meta
+  - request
 
 # Label to use when marking an issue as stale
 staleLabel: stale
 
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
-  Hi there — thanks for submitting this talk! It’s been a year since the last activity — would you mind taking a look to see if you’re still interested in presenting about this topic, and if the talk’s content is still up-to-date?
-
-  **If everything’s still good,** just drop a comment here and I’ll pop back into hibernation like a good little robot.
-
-  **If you’re no longer interested in giving this talk,** or the talk is out-of-date, feel free to close this issue.
-
-  Should I not hear back in a week, I’ll close this issue so you needn’t feel guilty about it. ❤️
-
-  Thanks for your contribution to the tech community in DC!
+  <p>Hi there — thanks for submitting this talk! It’s been a year since the last activity — would you mind taking a look to see if you’re still interested in presenting about this topic, and if the talk’s content is still up-to-date?</p>
+  <p><strong>If everything’s still good,</strong> just drop a comment here and I’ll pop back into hibernation like a good little robot.</p>
+  <p><strong>If you’re no longer interested in giving this talk,</strong> or the talk is out-of-date, feel free to close this issue.</p>
+  <p>Should I not hear back in a week, I’ll close this issue so you needn’t feel guilty about it. ❤️</p>
+  <p>Thanks for your contribution to the tech community in DC!</p>
 
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: >
-  Keep being awesome! 🤖✨
+  <p>Keep being awesome! 🤖✨</p>


### PR DESCRIPTION
A follow-up to #39, this PR fixes the issue preventing the bot from commenting (https://github.com/boyney123/auto-comment/pull/5) and switches the bot to post in HTML, which works better as seen at https://github.com/adunkman/speaking/issues/3.

As this is just a fix to #39, I’ll merge without review — but let me know if you have any feedback, and I’d be happy to hear it! 